### PR TITLE
Sibyl state hotfix

### DIFF
--- a/sibyl_python/SibylState.py
+++ b/sibyl_python/SibylState.py
@@ -6,7 +6,10 @@ class SibylState:
     config files and exclude particular parameters
     '''
     def __init__(self, state=None):
-        self.state = state
+        if state is None:
+            self.state = {}
+        else:
+            self.state = state
         self.createBlacklist()
 
     def createBlacklist(self):

--- a/sibyl_python/SibylState.py
+++ b/sibyl_python/SibylState.py
@@ -28,9 +28,12 @@ class SibylState:
             pickle.dump(cleanState, outfile)
 
     def loadState(self, realState, filename='.default'):
-        with open(filename, 'rb') as infile:
-            copyState = pickle.load(infile)
-        realState.update(copyState)
-        self.state = realState
+        try:
+            with open(filename, 'rb') as infile:
+                copyState = pickle.load(infile)
+            realState.update(copyState)
+            self.state = realState
+        except FileNotFoundError:
+            pass
 
 


### PR DESCRIPTION
Quick fix so that sibyl will load even when a default config is not defined.