### PR TITLE
Fixed histogram labelling for normal and retina displays by applying …

### DIFF
--- a/sibyl_python/SibylHistogram.py
+++ b/sibyl_python/SibylHistogram.py
@@ -46,7 +46,7 @@ class SibylHistogram(gl.GLViewWidget):
         pixRatio = super(SibylHistogram,self).devicePixelRatio()
         return trueWidth * pixRatio
 
-    def height(self):
+    def height(self, fixed=False):
         trueHeight = super(SibylHistogram,self).height()
         if fixed:
             return trueHeight
@@ -186,14 +186,15 @@ class SibylHistogram(gl.GLViewWidget):
     def drawLegend(self):
         margin = 11
         padding = 6
+        pixRatio = super(SibylHistogram,self).devicePixelRatio() #needed to scale font size and wstart
         self.qglColor(Qt.white)
         cmask = (self._parent.parameters['colorMask']).capitalize()
-        fsize = int(self.height()/14.0)
+        fsize = int(self.height()/(14.0*pixRatio))
         font = QFont("Times", fsize, QFont.Bold)
-        wstart = self.width(fixed=True) - fsize*8
-        self.renderText(wstart, 0.1*self.height(fixed=True),
+        wstart = self.width() - fsize*8*pixRatio
+        self.renderText(wstart/pixRatio, 0.1*self.height(fixed=True),
                 cmask, font=font)
-        self.renderText(wstart, 0.2*self.height(fixed=True), 
+        self.renderText(wstart/pixRatio, 0.2*self.height(fixed=True), 
                 self.txt, font=font)
 
     '''


### PR DESCRIPTION
…pixelRatio to _fontsize_ and _wstart_ offset on ll. 192-197. Also includes the missing _fixed=True_ in _def height_ on l. 49. Tested on macOS install using retina resolution and native resolution.