### PR TITLE
Adding smart cylinder.

### DIFF
--- a/scripts/sibyl
+++ b/scripts/sibyl
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#/usr/bin/env python3
 import sys
 import signal
 import json
@@ -209,6 +209,8 @@ class MainWindow(QtGui.QMainWindow):
         self.cobra.openFile(self.parameters["filename"])
         self.parameters["posArray"] = np.array(self.cobra.getXYZ()).T
         self.parameters["entries"] = self.cobra.getEntries()
+        self.parameters["boundaryRadius"] = self.cobra.getBoundaryRadius();
+        self.parameters["boundaryHalfz"] = self.cobra.getBoundaryHalfz();
 
     def readRat(self):
         event = int(self.event.text())

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os
 from subprocess import check_output, CalledProcessError
 
 
-VERSION = "0.2.0"
+VERSION = "0.2.1"
 
 try:
     RATROOT = os.environ["RATROOT"]

--- a/sibyl/Sibyl2DViewer.py
+++ b/sibyl/Sibyl2DViewer.py
@@ -125,6 +125,8 @@ class SibylWatchmanFlat(gl.GLScatterPlotItem):
     realcolors = np.array([0])
     weights = np.array([0])
     phi = 0 #Angle to rotate about 0 to 2pi or something
+    boundaryRadius = 1.0
+    boundaryHalfz = 1.0
     def __init__(self):
         super(SibylWatchmanFlat,self).__init__(pxMode=False, size=300)
 
@@ -141,6 +143,10 @@ class SibylWatchmanFlat(gl.GLScatterPlotItem):
     def setWeights(self, weights):
         self.weights = weights
 
+    def setBoundaries(self, radius, halfz):
+        self.boundaryRadius = radius
+        self.boundaryHalfz = halfz
+
     def project(self):
         # Cylindrical coordinates
         posX = (self.position.T)[0]
@@ -156,9 +162,9 @@ class SibylWatchmanFlat(gl.GLScatterPlotItem):
         ## Move this to a detector class, but for now, arbitrarily define
         ## various regions.
         ## displace top and bottom
-        zCut = 6300
-        rCut = 6400
-        vetoH = 6500
+        zCut = self.boundaryHalfz-100 #6300
+        rCut = self.boundaryRadius #6400
+        vetoH = zCut + 200 #6500
         flatSelect = (posZ<zCut)&(posZ>-zCut)&(posRho<rCut)
         flatPOS = np.array([theta[flatSelect], posZ[flatSelect], np.zeros(len(theta[flatSelect]))]).T
         flatCLR = self.realcolors[flatSelect]

--- a/sibyl/SibylTabEvent.py
+++ b/sibyl/SibylTabEvent.py
@@ -53,6 +53,7 @@ class SibylTabEvent(SibylTab):
         self.plot3DView = gl.GLScatterPlotItem(pxMode=False)
         self.plotTracks = gl.GLLinePlotItem(mode='lines', color=(1,0,0,0.1))
         self.plotFlatMap = SibylWatchmanFlat()
+        self.plotFlatMap.setBoundaries( self.parameters["boundaryRadius"], self.parameters["boundaryHalfz"] )
         self.glWin = Sibyl3DViewer(self.plot3DView, self.plotTracks, self.App)
         self.flatMapWindow = Sibyl2DViewer(self.plotFlatMap, self.App)
         self.layout.addWidget(self.flatMapWindow,0,0,9,8)

--- a/sibyl_cpp/snake.py
+++ b/sibyl_cpp/snake.py
@@ -36,6 +36,14 @@ class snake:
         self._getEntries.restype = c_int
         self._getEntries.argstypes = []
 
+        self._getBoundaryRadius = self.lib.getBoundaryRadius
+        self._getBoundaryRadius.restype = c_double
+        self._getBoundaryRadius.argstypes = []
+
+        self._getBoundaryHalfz = self.lib.getBoundaryHalfz
+        self._getBoundaryHalfz.restype = c_double
+        self._getBoundaryHalfz.argstypes = []
+
         self._getEvent = self.lib.getEvent
         self._getEvent.restype = c_void_p
         self._getEvent.argstypes = [c_int]
@@ -90,6 +98,12 @@ class snake:
 
     def getEntries(self):
         return self._getEntries()
+
+    def getBoundaryRadius(self):
+        return self._getBoundaryRadius()
+
+    def getBoundaryHalfz(self):
+        return self._getBoundaryHalfz()
 
     def getXYZ(self):
         pmtc = self._getPMTCount()


### PR DESCRIPTION
To allow for various sizes of detector, the default configuration attempts to determine the radius and height of inner pmts and separate them from veto pmts. This should allow the 2D flatmap to work with various cylindrical designs. There are some magic buffer parameters that would not work for extreme variations in detector design. That can be fixed later.